### PR TITLE
ディレクトリ構成を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
-FROM ruby:2.5.3
+FROM ruby:2.6.5
 
 # 必要なパッケージのインストール（基本的に必要になってくるものだと思うので削らないこと）
 RUN apt-get update -qq && \
     apt-get install -y build-essential \ 
-                       libpq-dev \        
-                       nodejs           
+    libpq-dev \        
+    nodejs           
 
 # 作業ディレクトリの作成、設定
-RUN mkdir /glenfiddich_management 
+RUN mkdir /task_management 
 ##作業ディレクトリ名をAPP_ROOTに割り当てて、以下$APP_ROOTで参照
-ENV APP_ROOT /glenfiddich_management
+ENV APP_ROOT /task_management
 WORKDIR $APP_ROOT
 
 # ホスト側（ローカル）のGemfileを追加する（ローカルのGemfileは【３】で作成）
-ADD ./Gemfile $APP_ROOT/Gemfile
-ADD ./Gemfile.lock $APP_ROOT/Gemfile.lock
+ADD ./task_management/Gemfile $APP_ROOT/Gemfile
+ADD ./task_management/Gemfile.lock $APP_ROOT/Gemfile.lock
 
 # Gemfileのbundle install
 RUN bundle install
-ADD . $APP_ROOT
+ADD ./task_management/ $APP_ROOT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   db:
     image: mysql:5.7
@@ -12,7 +12,7 @@ services:
     build: .
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
-      - .:/glenfiddich_management
+      - ./task_management:/task_management
     ports:
       - "3000:3000"
     links:

--- a/task_management/Gemfile
+++ b/task_management/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.3'
+ruby '2.6.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.0'

--- a/task_management/config/database.yml
+++ b/task_management/config/database.yml
@@ -19,14 +19,14 @@ default: &default
 
 development:
   <<: *default
-  database: glenfiddich_management_development
+  database: task_management_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: glenfiddich_management_test
+  database: task_management_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -49,6 +49,6 @@ test:
 #
 production:
   <<: *default
-  database: glenfiddich_management_production
-  username: glenfiddich_management
+  database: gtask_management_production
+  username: task_management
   password: <%= ENV['GLENFIDDICH_MANAGEMENT_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
## 概要
Dockerfileとdocker-compose.ymlの管理場所を
application配下と分けたかったのでディレクトリ構成を修正した

### やったこと
- Glenfiddich配下に `Dockerfile` と `docker-compose.yml` を配置し、
rails の application は task_management ディレクトリ配下に配置するように修正した
- また、railsアプリケーションのproject 名を docker 内でも mount先でも `task_management`
に統一した
- ruby の version を 2.6.5 に変更 (それにしたがってgemfile の version 指定も変更してあります)

また、database に関しても task_management{develop, test, production} に rename した。

**注意点**
変更を取り入れたあとは、project のルートディレクトリで 
`docker-compose up --build` を実行してください
また、DBが作成されなかった場合は、`docker-compose run web rails db:create` 
を実行すると良いと思われます