### PR TITLE
graphqlのクエリーの定義をtagsディレクトリに切り出す

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "editor.tabSize": 2,
+  "editor.rulers": [80],
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "workbench.iconTheme": "vscode-icons",
+  "eslint.autoFixOnSave": true,
+  "eslint.enable": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "editor.formatOnType": true,
+  "editor.formatOnSave": true
+}

--- a/task_management/app/graphql/mutations/create_user.rb
+++ b/task_management/app/graphql/mutations/create_user.rb
@@ -1,5 +1,5 @@
 module Mutations
-  class AddUser < GraphQL::Schema::RelayClassicMutation
+  class CreateUser < GraphQL::Schema::RelayClassicMutation
     argument :name, String, required: true
     argument :email, String, required: true
     argument :role, Integer, required: true

--- a/task_management/app/graphql/types/mutation_type.rb
+++ b/task_management/app/graphql/types/mutation_type.rb
@@ -1,7 +1,7 @@
 module Types
   class MutationType < Types::BaseObject
     field :createTask, mutation: Mutations::CreateTask
-    field :addUser, mutation: Mutations::AddUser
+    field :createUser, mutation: Mutations::CreateUser
     field :destroyUser, mutation: Mutations::DestroyUser
   end
 end

--- a/task_management/client/bundles/components/organisms/AddUserModal.jsx
+++ b/task_management/client/bundles/components/organisms/AddUserModal.jsx
@@ -127,7 +127,7 @@ export const AddUserModal = props => {
           variant="outlined"
           color="primary"
           onClick={() =>
-            props.addNewUser(name, email, role, password, passwordConfirmation)
+            props.createUser(name, email, role, password, passwordConfirmation)
           }
         >
           追加

--- a/task_management/client/bundles/components/organisms/MemberList.jsx
+++ b/task_management/client/bundles/components/organisms/MemberList.jsx
@@ -13,7 +13,7 @@ import { BoldText } from "../atoms/BoldText";
 import { IconButton } from "@material-ui/core";
 import DeleteIcon from "@material-ui/icons/Delete";
 import { AlertDialog } from "./ConfirmDialog";
-import gql from "graphql-tag";
+import { DESTROY_USER } from "../../tags/User";
 import { useMutation } from "@apollo/react-hooks";
 
 const useStyles = makeStyles({
@@ -25,20 +25,6 @@ const useStyles = makeStyles({
     width: "5rem"
   }
 });
-
-// ユーザー削除で使用する
-const DESTROY_USER = gql`
-  mutation($id: ID!, $currentUserId: Int!) {
-    destroyUser(input: { id: $id, currentUserId: $currentUserId }) {
-      users {
-        id
-        name
-        email
-        role
-      }
-    }
-  }
-`;
 
 export const MemberList = props => {
   const classes = useStyles();

--- a/task_management/client/bundles/containers/templates/DashboardContainer.jsx
+++ b/task_management/client/bundles/containers/templates/DashboardContainer.jsx
@@ -16,7 +16,7 @@ import DescriptionIcon from "@material-ui/icons/Description";
 import PeopleIcon from "@material-ui/icons/People";
 import { AddProjectModal } from "../../components/organisms/AddProjectModal";
 import { AddUserModal } from "../../components/organisms/AddUserModal";
-import { ADD_USER, USERS } from "../../tags/User";
+import { CREATE_USER, USERS } from "../../tags/User";
 import { ADD_TASK } from "../../tags/Task";
 import { useMutation, useQuery } from "@apollo/react-hooks";
 
@@ -38,7 +38,7 @@ export const DashboardContainer = props => {
 
   const [tasks, setTasks] = useState(props.tasks);
   const [addTask] = useMutation(ADD_TASK);
-  const [addUser] = useMutation(ADD_USER, {
+  const [createUser] = useMutation(CREATE_USER, {
     update(cache, { data: { addUser } }) {
       // 本当はここで cache.writeQuery を使っていい感じに users のリストを更新したい
       // const { users } = cache.readQuery({ query: USERS });
@@ -67,8 +67,14 @@ export const DashboardContainer = props => {
     setTasks(newTasks);
   };
 
-  const addNewUser = (name, email, role, password, passwordConfirmation) => {
-    addUser({
+  const handleSubmitUser = (
+    name,
+    email,
+    role,
+    password,
+    passwordConfirmation
+  ) => {
+    createUser({
       variables: {
         name: name,
         email: email,
@@ -79,7 +85,7 @@ export const DashboardContainer = props => {
     })
       .then(result => {
         // ユーザーの一覧に追加したメンバーを表示させるため
-        setUsersNode(usersNode.concat({ node: result.data.addUser.user }));
+        setUsersNode(usersNode.concat({ node: result.data.createUser.user }));
         setUserOpen(false);
       })
       .catch(e => {
@@ -155,8 +161,8 @@ export const DashboardContainer = props => {
       <AddUserModal
         open={userOpen}
         handleClose={() => setUserOpen(false)}
-        addNewUser={(name, email, role, password, passwordConfirmation) =>
-          addNewUser(name, email, role, password, passwordConfirmation)
+        createUser={(name, email, role, password, passwordConfirmation) =>
+          handleSubmitUser(name, email, role, password, passwordConfirmation)
         }
         errors={userErrors}
       />

--- a/task_management/client/bundles/containers/templates/DashboardContainer.jsx
+++ b/task_management/client/bundles/containers/templates/DashboardContainer.jsx
@@ -16,7 +16,8 @@ import DescriptionIcon from "@material-ui/icons/Description";
 import PeopleIcon from "@material-ui/icons/People";
 import { AddProjectModal } from "../../components/organisms/AddProjectModal";
 import { AddUserModal } from "../../components/organisms/AddUserModal";
-import gql from "graphql-tag";
+import { ADD_USER, USERS } from "../../tags/User";
+import { ADD_TASK } from "../../tags/Task";
 import { useMutation, useQuery } from "@apollo/react-hooks";
 
 const useStyles = makeStyles(theme => ({
@@ -28,62 +29,6 @@ const useStyles = makeStyles(theme => ({
     height: "100%"
   }
 }));
-
-const ADD_TASK = gql`
-  mutation($title: String!, $userId: Int!, $description: String!) {
-    createTask(
-      input: { title: $title, userId: $userId, description: $description }
-    ) {
-      task {
-        id
-        title
-        userId
-        description
-      }
-    }
-  }
-`;
-
-const ADD_USER = gql`
-  mutation(
-    $name: String!
-    $email: String!
-    $role: Int!
-    $password: String!
-    $passwordConfirmation: String!
-  ) {
-    addUser(
-      input: {
-        name: $name
-        email: $email
-        role: $role
-        password: $password
-        passwordConfirmation: $passwordConfirmation
-      }
-    ) {
-      user {
-        id
-        name
-        role
-      }
-    }
-  }
-`;
-
-const USERS = gql`
-  query {
-    users {
-      edges {
-        node {
-          id
-          email
-          name
-          role
-        }
-      }
-    }
-  }
-`;
 
 export const DashboardContainer = props => {
   const classes = useStyles();

--- a/task_management/client/bundles/tags/Task.js
+++ b/task_management/client/bundles/tags/Task.js
@@ -1,0 +1,16 @@
+import gql from "graphql-tag";
+
+export const ADD_TASK = gql`
+  mutation($title: String!, $userId: Int!, $description: String!) {
+    createTask(
+      input: { title: $title, userId: $userId, description: $description }
+    ) {
+      task {
+        id
+        title
+        userId
+        description
+      }
+    }
+  }
+`;

--- a/task_management/client/bundles/tags/User.js
+++ b/task_management/client/bundles/tags/User.js
@@ -1,0 +1,56 @@
+import gql from "graphql-tag";
+
+export const ADD_USER = gql`
+  mutation(
+    $name: String!
+    $email: String!
+    $role: Int!
+    $password: String!
+    $passwordConfirmation: String!
+  ) {
+    addUser(
+      input: {
+        name: $name
+        email: $email
+        role: $role
+        password: $password
+        passwordConfirmation: $passwordConfirmation
+      }
+    ) {
+      user {
+        id
+        name
+        role
+      }
+    }
+  }
+`;
+
+export const USERS = gql`
+  query {
+    users {
+      edges {
+        node {
+          id
+          email
+          name
+          role
+        }
+      }
+    }
+  }
+`;
+
+// ユーザー削除で使用する
+export const DESTROY_USER = gql`
+  mutation($id: ID!, $currentUserId: Int!) {
+    destroyUser(input: { id: $id, currentUserId: $currentUserId }) {
+      users {
+        id
+        name
+        email
+        role
+      }
+    }
+  }
+`;

--- a/task_management/client/bundles/tags/User.js
+++ b/task_management/client/bundles/tags/User.js
@@ -1,6 +1,6 @@
 import gql from "graphql-tag";
 
-export const ADD_USER = gql`
+export const CREATE_USER = gql`
   mutation(
     $name: String!
     $email: String!
@@ -8,7 +8,7 @@ export const ADD_USER = gql`
     $password: String!
     $passwordConfirmation: String!
   ) {
-    addUser(
+    createUser(
       input: {
         name: $name
         email: $email


### PR DESCRIPTION
### 概要
queryの定義が増えてくると、fileが長くて見づらいのと、
他のfileでも同じqueryを共有したいケースに備えて、qureyの定義をtagsディレクトリ配下に切り出した。

何かを参考にして、tagsディレクトリ配下にとりあえず置いているのですが、
もっといい管理方法が見つかれば教えて頂きたいです🙏

後、vscodeで開発すれば、インデントとかのルールを共有 && 気にしなくていいようになる
`.vscode/settings.json` を追加しました