### PR TITLE
enumの値が正しく渡せていなかった不具合を修正

### DIFF
--- a/task_management/app/graphql/types/role.rb
+++ b/task_management/app/graphql/types/role.rb
@@ -1,6 +1,6 @@
 class Types::Role < Types::BaseEnum
   value "owner"
   value "admin"
-  value "normal"
+  value "member"
   value "guest"
 end

--- a/task_management/app/graphql/types/role.rb
+++ b/task_management/app/graphql/types/role.rb
@@ -1,0 +1,6 @@
+class Types::Role < Types::BaseEnum
+  value "owner"
+  value "admin"
+  value "normal"
+  value "guest"
+end

--- a/task_management/app/graphql/types/user_type.rb
+++ b/task_management/app/graphql/types/user_type.rb
@@ -2,7 +2,7 @@ module Types
   class UserType < Types::BaseObject
     field :id, ID, null: false
     field :name, String, null: false
-    field :role, Integer, null: false
+    field :role, Role, null: false
     field :email, String, null: false
   end
 end

--- a/task_management/app/models/user.rb
+++ b/task_management/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token
-  enum role: { owner: 0, admin: 1, normal: 2, guest: 3 }
+  enum role: { owner: 0, admin: 1, member: 2, guest: 3 }
   EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
   has_many :projects

--- a/task_management/client/bundles/components/molecules/MemberTableTr.jsx
+++ b/task_management/client/bundles/components/molecules/MemberTableTr.jsx
@@ -5,10 +5,10 @@ import styled from "styled-components";
 
 export const MemberTableTr = props => {
   const roles = new Map([
-    [0, "オーナー"],
-    [1, "管理者"],
-    [2, "一般"],
-    [3, "ゲスト"]
+    ["owner", "オーナー"],
+    ["admin", "管理者"],
+    ["normal", "一般"],
+    ["guest", "ゲスト"]
   ]);
 
   return (

--- a/task_management/client/bundles/components/molecules/MemberTableTr.jsx
+++ b/task_management/client/bundles/components/molecules/MemberTableTr.jsx
@@ -7,7 +7,7 @@ export const MemberTableTr = props => {
   const roles = new Map([
     ["owner", "オーナー"],
     ["admin", "管理者"],
-    ["normal", "一般"],
+    ["member", "メンバー"],
     ["guest", "ゲスト"]
   ]);
 

--- a/task_management/spec/models/user_spec.rb
+++ b/task_management/spec/models/user_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of(:mail) }
     it { is_expected.to validate_uniqueness_of(:mail).case_insensitive }
     it { is_expected.to validate_presence_of(:role) }
-    it { is_expected.to define_enum_for(:role).with_values([:owner, :admin, :normal, :guest]) }
+    it { is_expected.to define_enum_for(:role).with_values([:owner, :admin, :member, :guest]) }
   end
 end


### PR DESCRIPTION
## 概要
role は ruby 上で enumで定義しているのだが、そのenum値が graphql で正しく渡せておらず、
role はDBに保存されている値に関わらず、全て `0` で渡されていた。
なので、enum type を定義し、正しくroleがenumと同様に渡せるように修正した


修正方法としては下記を参考にした
https://github.com/rmosolgo/graphql-ruby/blob/master/guides/type_definitions/enums.md