### PR TITLE
Merge pull request #55 from yusuke-eto/add_client_file

### DIFF
--- a/task_management/client/bundles/containers/pages/DashboardPage.jsx
+++ b/task_management/client/bundles/containers/pages/DashboardPage.jsx
@@ -1,18 +1,19 @@
 import React from "react";
 import { DashboardContainer } from "../templates/DashboardContainer";
+import { ApolloProvider } from "@apollo/react-hooks";
+import { client } from "../../../lib/ApolloClient/client"
 import { Header } from "../../components/organisms/Header";
-import { ApolloProviderWrapper } from "../../components/providers/ApolloProviderWrapper";
 
 const DashboardPage = props => {
   return (
-    <ApolloProviderWrapper>
+    <ApolloProvider client={client}>
       <Header user={props.user} />
       <DashboardContainer
         tasks={props.tasks}
         users={props.users}
         workspaceId={props.workspaceId}
       />
-    </ApolloProviderWrapper>
+    </ApolloProvider>
   );
 };
 

--- a/task_management/client/lib/ApolloClient/client.js
+++ b/task_management/client/lib/ApolloClient/client.js
@@ -1,0 +1,25 @@
+import { ApolloClient } from "apollo-client";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import { HttpLink } from "apollo-link-http";
+import { ApolloLink, concat } from "apollo-link";
+import { GRAPHQL_ENDPOINT } from "../../bundles/Constants/graphqlEndPoint";
+const csrfToken = ReactOnRails.authenticityToken();
+
+const cache = new InMemoryCache();
+const link = new HttpLink({
+  uri: GRAPHQL_ENDPOINT
+});
+
+const authMiddleware = new ApolloLink((operation, forward) => {
+  operation.setContext({
+    headers: {
+      "X-CSRF-Token": csrfToken
+    }
+  });
+  return forward(operation);
+});
+
+export const client = new ApolloClient({
+  cache: cache,
+  link: concat(authMiddleware, link)
+});


### PR DESCRIPTION
## 概要
今までは、ApolloProviderWrapperという Wrapper用のcomponentを作成し、
それをトップレベルに持ってくることで、apollo clientを使うようにしていたが、
若干筋が悪かったので、あくまでトップレベルには　ApolloProviderを使用し、
client の部分だけを exportするようにした