### PR TITLE
メンバー詳細ページを追加

### DIFF
--- a/task_management/app/controllers/workspace_members_controller.rb
+++ b/task_management/app/controllers/workspace_members_controller.rb
@@ -3,4 +3,25 @@
 class WorkspaceMembersController < ApplicationController
   def index
   end
+
+  def show
+    @projects = current_workspace
+                  .projects
+                  .last(20)
+                  .to_json(
+                    only: [:title, :description, :deadline],
+                    include: {
+                      tasks: {
+                        only: [:title, :description, :deadline]
+                      }
+                    }
+                  )
+    @workspace_member = current_workspace
+                          .workspace_members
+                          .find(params[:id])
+
+  rescue ActiveRecord::RecordNotFound
+    flash[:alert] = "該当のユーザーが存在しません"
+    redirect_back(fallback_location: root_path)
+  end
 end

--- a/task_management/app/graphql/types/query_type.rb
+++ b/task_management/app/graphql/types/query_type.rb
@@ -13,16 +13,23 @@ module Types
             User.all
           end
     field :workspace_members, [Types::WorkspaceMemberType], null: true, description: '現在使用しているワークスペースの全メンバー'
-    field :projects,  [Types::ProjectType], null: true, description: 'ログイン中のワークスペースに紐づくプロジェクト'
-    
+    field :projects,  [Types::ProjectType], null: true do
+      argument :workspace_member_id, Integer, required: false
+      description 'プロジェクトの一覧を取得する'
+    end
+
     def workspace_members
       workspace = context[:current_workspace]
       workspace.workspace_members
     end
 
-    def projects
+    def projects(workspace_member_id: nil)
       workspace = context[:current_workspace]
-      workspace.projects
+
+      projects = workspace.projects
+      projects = projects.where(workspace_member_id: workspace_member_id) if !workspace_member_id.nil?
+
+      projects
     end
   end
 end

--- a/task_management/app/views/workspace_members/show.html.slim
+++ b/task_management/app/views/workspace_members/show.html.slim
@@ -1,0 +1,1 @@
+= react_component("WorkspaceMemberPage", props: {workspaceMember: @workspace_member}, prerender: false)

--- a/task_management/client/bundles/components/atoms/Link.jsx
+++ b/task_management/client/bundles/components/atoms/Link.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const Link = ({message, href}) => {
+return <a href={href}>{message}</a>;
+};

--- a/task_management/client/bundles/components/organisms/MemberSortTable.jsx
+++ b/task_management/client/bundles/components/organisms/MemberSortTable.jsx
@@ -7,10 +7,7 @@ import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
 import Paper from "@material-ui/core/Paper";
 import { MemberSortTableHead } from "./MemberSortTableHead"
-
-function createData(name, role, red, yellow, green) {
-  return { name, role, red, yellow, green };
-}
+import { Link } from "../../components/atoms/Link"
 
 function desc(a, b, orderBy) {
   if (b[orderBy] < a[orderBy]) {
@@ -100,7 +97,9 @@ export const MemberSortTable = ({workspaceMembers}) => {
   const [selected, setSelected] = useState([]);
   const [page] = useState(0);
   const rowDatas = workspaceMembers.map(
-    workspaceMember => createData(workspaceMember.user.name, workspaceMember.role, 5, 5, 5)
+    workspaceMember => {
+      return { id: workspaceMember.id, name: workspaceMember.user.name, role: workspaceMember.role, red: 5, yellow: 5, green: 5 }
+    }
   )
   const [rowsPerPage] = useState(workspaceMembers.length);
 
@@ -177,7 +176,7 @@ export const MemberSortTable = ({workspaceMembers}) => {
                       key={row.name}
                       selected={isItemSelected}
                     >
-                      <TableCell align="center" className={classes.member_td}>{row.name}</TableCell>
+                      <TableCell align="center" className={classes.member_td}><Link href={`/workspace_members/${row.id}`} message={row.name} /></TableCell>
                       <TableCell align="right">{row.roles}</TableCell>
                       <TableCell align="right"><span className={classes.red}>{row.red}</span></TableCell>
                       <TableCell align="right"><span className={classes.yellow}>{row.yellow}</span></TableCell>

--- a/task_management/client/bundles/containers/pages/WorkspaceMemberPage.jsx
+++ b/task_management/client/bundles/containers/pages/WorkspaceMemberPage.jsx
@@ -1,0 +1,123 @@
+import React, { useState } from "react";
+import { Header } from "../../components/organisms/Header";
+import { makeStyles } from "@material-ui/core/styles";
+import Drawer from "@material-ui/core/Drawer";
+import CssBaseline from "@material-ui/core/CssBaseline";
+import AppBar from "@material-ui/core/AppBar";
+import List from "@material-ui/core/List";
+import Typography from "@material-ui/core/Typography";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemIcon from "@material-ui/core/ListItemIcon";
+import ListItemText from "@material-ui/core/ListItemText";
+import WorkIcon from "@material-ui/icons/Work";
+import { TaskTable } from "../../components/organisms/TaskTable";
+import { WORKSPACE_MEMBERS_PROJECTS } from "../../tags/WorkspaceMember"
+import { ApolloProvider } from "@apollo/react-hooks";
+import { client } from "../../../lib/ApolloClient/client";
+import { useQuery } from "@apollo/react-hooks";
+import { LoadingPage } from "./LoadingPage";
+
+const drawerWidth = 240;
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: "flex"
+  },
+  appBar: {
+    zIndex: theme.zIndex.drawer + 1
+  },
+  list: {
+    backgroundColor: "#313985"
+  },
+  listText: {
+    color: "#fff"
+  },
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0
+  },
+  drawerPaper: {
+    width: drawerWidth
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3)
+  },
+  toolbar: theme.mixins.toolbar
+}));
+
+function WorkspaceMemberPage({workspaceMember}) {
+  const classes = useStyles();
+  const { loading, error, data } = useQuery(WORKSPACE_MEMBERS_PROJECTS, {
+    variables: { workspaceMemberId: workspaceMember.id },
+  })
+  // table に表示されている Project の index を管理する
+  const [activeIndex, setAcitveIndex] = useState(0);
+
+  if (loading == true) {
+    return <LoadingPage />;
+  }
+
+  const changeActiveIndex = index => {
+    setAcitveIndex(index);
+  };
+
+  return (
+    <>
+      <div className={classes.root}>
+        <CssBaseline />
+        <AppBar position="fixed" className={classes.appBar}>
+          <Header />
+        </AppBar>
+        <Drawer
+          className={classes.drawer}
+          variant="permanent"
+          classes={{
+            paper: classes.drawerPaper
+          }}
+        >
+          <div className={classes.toolbar} />
+          <List className={classes.list}>
+            <ListItem>
+              <Typography
+                variant="h6"
+                align="left"
+                className={classes.listText}
+              >
+                Project
+              </Typography>
+            </ListItem>
+            {data.projects.map((project, index) => (
+              <ListItem
+                button
+                key={index}
+                selected={activeIndex == index}
+                onClick={() => changeActiveIndex(index)}
+              >
+                <ListItemIcon style={{ color: "white" }}>
+                  <WorkIcon />
+                </ListItemIcon>
+                <ListItemText
+                  primary={project.title}
+                  className={classes.listText}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Drawer>
+        <main className={classes.content}>
+          <div className={classes.toolbar} />
+          {data.projects[activeIndex] && (
+            <TaskTable tasks={data.projects[activeIndex].tasks} />
+          )}
+        </main>
+      </div>
+    </>
+  );
+}
+
+export default props => (
+  <ApolloProvider client={client}>
+    <WorkspaceMemberPage {...props} />
+  </ApolloProvider>
+);

--- a/task_management/client/bundles/tags/WorkspaceMember.js
+++ b/task_management/client/bundles/tags/WorkspaceMember.js
@@ -71,3 +71,15 @@ export const DESTROY_WORKSPACE_MEMBER = gql`
     }
   }
 `;
+
+export const WORKSPACE_MEMBERS_PROJECTS  = gql`
+  query(
+    $workspaceMemberId: Int
+  ) {
+    projects(workspaceMemberId: $workspaceMemberId) {
+      title
+      description
+      workspaceMemberId
+    }
+  }
+`

--- a/task_management/client/packs/application.js
+++ b/task_management/client/packs/application.js
@@ -16,6 +16,7 @@ import FlashContent from "../bundles/components/molecules/FlashContent";
 import Flash from "../bundles/components/organisms/Flash";
 import RegistrationUserPage from "../bundles/containers/pages/RegistrationUserPage";
 import WorkspaceMembersPage from "../bundles/containers/pages/WorkspaceMembersPage";
+import WorkspaceMemberPage from  "../bundles/containers/pages/WorkspaceMemberPage";
 
 ReactOnRails.register({
   DashboardPage,
@@ -24,5 +25,6 @@ ReactOnRails.register({
   FlashContent,
   Flash,
   RegistrationUserPage,
-  WorkspaceMembersPage
+  WorkspaceMembersPage,
+  WorkspaceMemberPage
 });

--- a/task_management/config/routes.rb
+++ b/task_management/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   post 'registration', to: 'registrations#create'
 
   resources :users, only: %i(new create)
-  resources :workspace_members, only: %i(index)
+  resources :workspace_members, only: %i(index show)
 
   resources :projects, only: %i(index)
 


### PR DESCRIPTION
## 概要
ダッシュボードからメンバー詳細画面(メンバーが担当しているタスクがパッと確認できる画面)
が必要だったので、画面の作成と、ダッシュボード画面のメンバーの名前をその詳細画面へのリンクにした


![Feb-24-2020 02-14-18](https://user-images.githubusercontent.com/39816391/75116406-67420e00-56ab-11ea-908a-d1b4340944aa.gif)

